### PR TITLE
fix: Specify main branch for Antigen installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ zplug "choplin/cclog"
 #### Antigen
 
 ```bash
-antigen bundle choplin/cclog
+antigen bundle choplin/cclog@main
 ```
 
 #### Zgen


### PR DESCRIPTION
## Summary
This PR fixes the Antigen installation command in the README to explicitly specify the `main` branch.

## Problem
Antigen defaults to looking for the `master` branch when installing plugins. Since this repository uses `main` as the default branch, users following the current installation instructions would encounter an error.

## Solution
Updated the installation command from:
```bash
antigen bundle choplin/cclog
```
to:
```bash
antigen bundle choplin/cclog@main
```
This ensures that Antigen correctly fetches from the main branch for proper installation.